### PR TITLE
package.json - browserify support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "multiselect",
+  "version": "2.0.0",
+  "description": "jQuery multiselect plugin with two sides",
+  "main": "src/multiselect.min.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/crlcu/multiselect.git"
+  },
+  "keywords": [
+    "multiselect"
+  ],
+  "author": "Adrian Crisan <adrian.crisan88@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/crlcu/multiselect/issues"
+  },
+  "homepage": "https://github.com/crlcu/multiselect#readme"
+}


### PR DESCRIPTION
Hey,

First of all, your plugin looks great. Have u consider adding it to npm registery? I'm using a setup when the packages can be only installed via npm, so its kinda obstacle to me.

I will be fine without putting it into registery, all I need is package.json file in the repo, because since version 2.x of npm, packages can be installed from github :)

edit:

Apperantly that's not all. I've forked the repo, created simple package.json, installed via `npm install pagenoare/multiselect`. I've tried to use it within the code:

`require('multiselect');`

but building the project gives me error:
```
Error: Cannot find module 'multiselect' from PATH
Warning: Error running grunt-browserify. Use --force to continue.
```

Thanks!