### PR TITLE
Allow move up/down to work within optgroups

### DIFF
--- a/dist/js/multiselect.js
+++ b/dist/js/multiselect.js
@@ -296,7 +296,7 @@ if (typeof jQuery === 'undefined') {
 
                     self.doNotSortRight = true;
                     
-                    var $options = self.$right.children(':selected:not(span):not(.hidden)');
+                    var $options = self.$right.find(':selected:not(span):not(.hidden)');
 
                     $options.first().prev().before($options);
 
@@ -308,7 +308,7 @@ if (typeof jQuery === 'undefined') {
 
                     self.doNotSortRight = true;
 
-                    var $options = self.$right.children(':selected:not(span):not(.hidden)');
+                    var $options = self.$right.find(':selected:not(span):not(.hidden)');
                     
                     $options.last().next().after($options);
 


### PR DESCRIPTION
A simple change that means ~~sorting~~move up/down works within optgroups. I might also add moving optgroups if the client requires it.