### PR TITLE
Update jquery dependency and fix tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
     "gulp-strip-debug": "^1.1.0",
     "gulp-uglify": "^2.0.0",
     "jasmine": "^2.5.3"
+  },
+  "dependencies": {
+    "jquery": ">=1.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,8 +25,5 @@
     "gulp-strip-debug": "^1.1.0",
     "gulp-uglify": "^2.0.0",
     "jasmine": "^2.5.3"
-  },
-  "dependencies": {
-    "jQuery": "^1.7"
   }
 }

--- a/tests.html
+++ b/tests.html
@@ -11,9 +11,9 @@
     <script type="text/javascript" src="lib/jasmine-jquery-1.1.2.js"></script>
     <script type="text/javascript" src="lib/jquery.simulate.js"></script>
 
-    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-    <script type="text/javascript" src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
-    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/prettify/r298/prettify.min.js"></script>
+    <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+    <script type="text/javascript" src="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
+    <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/prettify/r298/prettify.min.js"></script>
     <script type="text/javascript" src="dist/js/multiselect.min.js"></script>
 
     <!-- include spec files here... -->


### PR DESCRIPTION
The camelCase jQuery dependency is deprecated in newer versions of npm, since package names are case-insensitive. When I install your package, I get this message:

```
npm WARN deprecated jQuery@1.7.4: This is deprecated. Please use 'jquery' (all lowercase).
```

Also, the `package.json` allows for jquery up to 1.7, but the README says this package only needs 1.7 or higher. Either we can reflect this correctly in the `package.json` (latest commit) or get rid of jquery as a dependency entirely (first commit). This is what other packages do (see for example [jquery.autocomplete](https://github.com/lloydwatkin/jquery.autocomplete/blob/master/package.json)). 

Thank you for your work on this library!