### PR TITLE
add destroyData method for reuse select

### DIFF
--- a/dist/js/multiselect.js
+++ b/dist/js/multiselect.js
@@ -662,6 +662,11 @@ if (typeof jQuery === 'undefined') {
         });
     };
 
+    $.fn.destroyData = function( ) {
+        $(this).data('crlcu.multiselect', null);
+        return this;
+    };
+
     // append options
     // then set the selected attribute to false
     $.fn.move = function( $options ) {


### PR DESCRIPTION
Ex:

`
var $multiSelect = null;
$.ajax({
            url: '...',
            type: 'post',
            dataType: 'json',
            success: function (respuesta) {
               for (var i = 0; i < total; i++) {
                    $('#select_items').append($('<option>', {
                        value: respuesta.listado[i].id,
                        text: respuesta.listado[i].titulo
                    }));
                }

                if ($multiSelect !== null) {
                    $multiSelect.destroyData();
                }

                $multiSelect = $('.js-multiselect').multiselect({
                    keepRenderingSort: true,
                    right: '#select_items_final',
                    rightAll: '#derecha_todo',
                    rightSelected: '#derecha_seleccionado',
                    leftSelected: '#izquierda_seleccionado',
                    leftAll: '#izquierda_todo'
                });
            },
            data: AUXdata
        });
`