### PR TITLE
Use .prop('disabled', true|false)

### DIFF
--- a/dist/js/multiselect.js
+++ b/dist/js/multiselect.js
@@ -754,7 +754,7 @@ if (typeof jQuery === 'undefined') {
             });
         }
         if(isFirefox){
-            this.attr('disabled', false)
+            this.prop('disabled', false)
         }
 
         return this;
@@ -772,7 +772,7 @@ if (typeof jQuery === 'undefined') {
             });
         }
         if(isFirefox){
-            this.attr('disabled', true)
+            this.prop('disabled', true)
         }
         return this;
     };


### PR DESCRIPTION
Setting the "disabled" property should be done using `.prop()`, not `.attr()`. Using `.attr()` does not work as expected on Firefox 71.0: the options are never reenabled when searching. [.prop()](https://api.jquery.com/prop/) is the proper method for setting element properties since jQuery 1.6.