### PR TITLE
removed return before call to self.callbacks.moveToRight.  The return…

### DIFF
--- a/dist/js/multiselect.js
+++ b/dist/js/multiselect.js
@@ -367,14 +367,14 @@ if (typeof jQuery === 'undefined') {
             moveToRight: function( $options, event, silent, skipStack ) {
                 var self = this;
 
-                if ( typeof self.callbacks.moveToRight == 'function' ) {
-                    return self.callbacks.moveToRight( self, $options, event, silent, skipStack );
-                }
-
                 if ( typeof self.callbacks.beforeMoveToRight == 'function' && !silent ) {
                     if ( !self.callbacks.beforeMoveToRight( self.$left, self.$right, $options ) ) {
                         return false;
                     }
+                }
+
+                if ( typeof self.callbacks.moveToRight == 'function' ) {
+                    self.callbacks.moveToRight( self, $options, event, silent, skipStack );
                 }
 
                 self.moveFromAtoB(self.$left, self.$right, $options, event, silent, skipStack);


### PR DESCRIPTION
… prevents the function from continuing with the rest of the code in the method such as calling the afterMoveToRight.

moved the code calling the beforeMoveToRight before the call to moveToRight.
Performed similar actions in moveToLeft function.

This pull request addresses the issue I opened.  I haven't had the chance to look through all of the code to see if there might be similar issues with other callbacks.  I addressed the issues impacting me directly for a project on which I was working.